### PR TITLE
Implement automated digest pipeline

### DIFF
--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -1,0 +1,49 @@
+name: Digest Automation
+
+on:
+  push:
+    paths:
+      - 'digests/**.md'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install openai requests python-dotenv
+      - name: Run pipeline
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
+          TRANSISTOR_API_KEY: ${{ secrets.TRANSISTOR_API_KEY }}
+          HUGGINGFACE_TOKEN: ${{ secrets.HUGGINGFACE_TOKEN }}
+        run: |
+          for f in digests/*.md; do
+            python scripts/run_pipeline.py "$f"
+          done
+      - name: Commit outputs
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add outputs metadata
+          git commit -m "Automated digest outputs" || echo "No changes"
+          git push
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ github.run_number }}
+          files: |
+            outputs/pdfs/*
+            outputs/podcasts/*.mp3
+            outputs/social/*.json
+            outputs/archive/*.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -38,3 +38,21 @@ This site is indexed with schema.org metadata, signed updates, and regular struc
 **License:** CC BY-NC 4.0  
 **Maintained by:** Justin Waldrop  
 [ohmbudsman.com](https://ohmbudsman.com)
+
+## 🚀 Automated Digest Pipeline
+
+New markdown files placed in `digests/` trigger the GitHub Actions workflow `automation.yml` which runs the following scripts located under `scripts/`:
+
+| Script | Purpose |
+| ------ | ------- |
+| `generate_pdf.py` | Convert the digest markdown to a styled PDF saved in `outputs/pdfs/` |
+| `create_social_snippets.py` | Produce social media highlights saved as JSON in `outputs/social/` |
+| `generate_podcast.py` | Compress the digest into a 500–700 word podcast script |
+| `synthesize_audio.py` | Generate an MP3 narration from the script and save to `outputs/podcasts/` |
+| `update_metadata.py` | Append a record to `metadata/content_index.csv` |
+| `archive_assets.py` | Zip assets and upload to HuggingFace for archival |
+
+The workflow requires the following repository secrets:
+`OPENAI_API_KEY`, `ELEVENLABS_API_KEY`, `TRANSISTOR_API_KEY`, and `HUGGINGFACE_TOKEN`.
+
+All generated assets are committed back to the repository and attached to a GitHub Release tagged with the digest name.

--- a/digests/20240607_Sample.md
+++ b/digests/20240607_Sample.md
@@ -1,0 +1,26 @@
+# Section 1: Example
+- 📰 Example bullet.
+
+# Section 2: Example
+- 💡 Insight bullet.
+
+# Section 3: Example
+- 📈 Market bullet.
+
+# Section 4: Example
+- ⚙️ Tech bullet.
+
+# Section 5: Example
+- 🏛️ Policy bullet.
+
+# Section 6: Example
+- 🎓 Education bullet.
+
+# Section 7: Example
+- 📊 Data bullet.
+
+# Section 8: Example
+- 🚀 Next bullet.
+
+# Section 9: Example
+- 🎯 Conclusion bullet.

--- a/metadata/content_index.csv
+++ b/metadata/content_index.csv
@@ -1,0 +1,1 @@
+date,title,pdf_path,podcast_path,social_path,sha256,version

--- a/scripts/archive_assets.py
+++ b/scripts/archive_assets.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Archive generated assets to a HuggingFace dataset."""
+
+from __future__ import annotations
+
+import os
+import sys
+import zipfile
+from pathlib import Path
+
+import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+HF_TOKEN = os.getenv("HUGGINGFACE_TOKEN")
+if not HF_TOKEN:
+    sys.exit("HUGGINGFACE_TOKEN not set")
+
+def create_zip(files: list[Path], out_path: Path) -> Path:
+    with zipfile.ZipFile(out_path, "w") as zf:
+        for f in files:
+            zf.write(f, arcname=f.name)
+    return out_path
+
+
+def upload_zip(zip_path: Path, repo: str) -> None:
+    headers = {"Authorization": f"Bearer {HF_TOKEN}"}
+    with zip_path.open("rb") as f:
+        resp = requests.post(
+            f"https://huggingface.co/api/datasets/{repo}/upload",
+            headers=headers,
+            files={"file": (zip_path.name, f)},
+        )
+    print("HuggingFace:", resp.status_code)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 3:
+        sys.exit("Usage: archive_assets.py ZIP_NAME FILE1 [FILE2 ...]")
+    zip_name = sys.argv[1]
+    files = [Path(p) for p in sys.argv[2:]]
+    out = Path("outputs/archive")
+    out.mkdir(parents=True, exist_ok=True)
+    zip_path = create_zip(files, out / zip_name)
+    upload_zip(zip_path, "ohmbudsman/digests")

--- a/scripts/create_social_snippets.py
+++ b/scripts/create_social_snippets.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Generate social snippets from a digest markdown file using OpenAI."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import openai
+from dotenv import load_dotenv
+
+load_dotenv()
+
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+if not OPENAI_API_KEY:
+    sys.exit("OPENAI_API_KEY not set")
+openai.api_key = OPENAI_API_KEY
+
+PROMPT = (
+    "Extract 3-5 short insight capsules (<=280 chars each), "
+    "a LinkedIn summary, and one Mastodon caption from the following markdown. "
+    "Respond in JSON with keys 'insights', 'linkedin', 'mastodon'."
+)
+
+
+def create_snippets(md_path: Path, out_dir: Path) -> Path:
+    text = md_path.read_text(encoding="utf-8")
+    messages = [
+        {"role": "system", "content": PROMPT},
+        {"role": "user", "content": text},
+    ]
+    resp = openai.ChatCompletion.create(model="gpt-4o", messages=messages, temperature=0.4)
+    content = resp.choices[0].message.content
+    try:
+        data = json.loads(content)
+    except json.JSONDecodeError:
+        data = {"raw": content}
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_file = out_dir / f"{md_path.stem}.json"
+    out_file.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    print(f"✔ Social snippets saved to {out_file}")
+    return out_file
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        sys.exit("Usage: create_social_snippets.py DIGEST_MD")
+    md_file = Path(sys.argv[1])
+    create_snippets(md_file, Path("outputs/social"))

--- a/scripts/generate_pdf.py
+++ b/scripts/generate_pdf.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Convert a markdown digest to PDF using pandoc."""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+def sha256_of(path: Path) -> str:
+    data = path.read_bytes()
+    return hashlib.sha256(data).hexdigest()
+
+
+def generate_pdf(md_path: Path, out_dir: Path) -> Path:
+    if not md_path.exists():
+        raise FileNotFoundError(md_path)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    sha = sha256_of(md_path)
+    date = datetime.utcnow().strftime("%Y-%m-%d")
+    version = "1.0"
+    # Append footer with metadata
+    footer = f"\n\n---\nGenerated {date} | version {version} | SHA256 {sha}\n"
+    temp_md = out_dir / (md_path.stem + "_tmp.md")
+    temp_md.write_text(md_path.read_text(encoding="utf-8") + footer, encoding="utf-8")
+
+    pdf_path = out_dir / (md_path.stem + ".pdf")
+    subprocess.run(
+        ["pandoc", str(temp_md), "--pdf-engine=xelatex", "-o", str(pdf_path)],
+        check=True,
+    )
+    temp_md.unlink()
+    print(f"✔ PDF generated at {pdf_path}")
+    return pdf_path
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        sys.exit("Usage: generate_pdf.py DIGEST_MD")
+    md_file = Path(sys.argv[1])
+    out = Path("outputs/pdfs")
+    generate_pdf(md_file, out)

--- a/scripts/generate_podcast.py
+++ b/scripts/generate_podcast.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Create a podcast script from a digest using OpenAI."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import openai
+from dotenv import load_dotenv
+
+load_dotenv()
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+if not OPENAI_API_KEY:
+    sys.exit("OPENAI_API_KEY not set")
+openai.api_key = OPENAI_API_KEY
+
+PROMPT = (
+    "Compress the following digest into a 500-700 word podcast script. "
+    "Write in a concise, conversational tone."
+)
+
+
+def generate_script(md_path: Path, out_dir: Path) -> Path:
+    text = md_path.read_text(encoding="utf-8")
+    messages = [
+        {"role": "system", "content": PROMPT},
+        {"role": "user", "content": text},
+    ]
+    resp = openai.ChatCompletion.create(model="gpt-4o", messages=messages, temperature=0.4)
+    script = resp.choices[0].message.content.strip()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_file = out_dir / f"{md_path.stem}_script.txt"
+    out_file.write_text(script, encoding="utf-8")
+    print(f"✔ Podcast script saved to {out_file}")
+    return out_file
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        sys.exit("Usage: generate_podcast.py DIGEST_MD")
+    md_file = Path(sys.argv[1])
+    generate_script(md_file, Path("outputs/podcasts"))

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Run the full automation pipeline for a digest file."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from generate_pdf import generate_pdf
+from create_social_snippets import create_snippets
+from generate_podcast import generate_script
+from synthesize_audio import synthesize
+from update_metadata import update_csv
+from archive_assets import create_zip, upload_zip
+
+
+def run(md_path: Path) -> None:
+    pdf = generate_pdf(md_path, Path("outputs/pdfs"))
+    social = create_snippets(md_path, Path("outputs/social"))
+    script = generate_script(md_path, Path("outputs/podcasts"))
+    mp3, transcript = synthesize(script, Path("outputs/podcasts"))
+    update_csv(md_path, pdf, mp3, social)
+    zip_path = Path("outputs/archive") / f"{md_path.stem}.zip"
+    create_zip([pdf, mp3, transcript, social], zip_path)
+    upload_zip(zip_path, "ohmbudsman/digests")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        sys.exit("Usage: run_pipeline.py DIGEST_MD")
+    run(Path(sys.argv[1]))

--- a/scripts/synthesize_audio.py
+++ b/scripts/synthesize_audio.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Synthesize podcast audio using ElevenLabs API."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+EL_API = os.getenv("ELEVENLABS_API_KEY")
+TRANSISTOR_API = os.getenv("TRANSISTOR_API_KEY")
+if not EL_API:
+    sys.exit("ELEVENLABS_API_KEY not set")
+
+VOICE_ID = "21m00Tcm4TlvDq8ikWAM"  # default voice
+
+
+def synthesize(script_path: Path, out_dir: Path) -> tuple[Path, Path]:
+    text = script_path.read_text(encoding="utf-8")
+    headers = {
+        "xi-api-key": EL_API,
+        "Content-Type": "application/json",
+    }
+    payload = {
+        "text": text,
+        "voice_settings": {"stability": 0.5, "similarity_boost": 0.75},
+    }
+    resp = requests.post(
+        f"https://api.elevenlabs.io/v1/text-to-speech/{VOICE_ID}",
+        headers=headers,
+        data=json.dumps(payload),
+    )
+    resp.raise_for_status()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    mp3_path = out_dir / f"{script_path.stem}.mp3"
+    mp3_path.write_bytes(resp.content)
+    transcript_path = out_dir / f"{script_path.stem}.txt"
+    transcript_path.write_text(text, encoding="utf-8")
+    print(f"✔ Audio saved to {mp3_path}")
+    if TRANSISTOR_API:
+        upload_to_transistor(mp3_path, transcript_path)
+    return mp3_path, transcript_path
+
+
+def upload_to_transistor(mp3: Path, transcript: Path) -> None:
+    headers = {"x-api-key": TRANSISTOR_API}
+    files = {"audio_file": mp3.open("rb"), "transcript": transcript.open("rb")}
+    resp = requests.post("https://api.transistor.fm/v1/episodes", headers=headers, files=files)
+    print("Transistor:", resp.status_code)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        sys.exit("Usage: synthesize_audio.py SCRIPT_TXT")
+    synthesize(Path(sys.argv[1]), Path("outputs/podcasts"))

--- a/scripts/update_metadata.py
+++ b/scripts/update_metadata.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Append digest metadata to metadata/content_index.csv."""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+def compute_sha(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def update_csv(md_path: Path, pdf: Path, mp3: Path, social: Path, version: str = "1.0") -> None:
+    date = datetime.utcnow().strftime("%Y-%m-%d")
+    sha = compute_sha(md_path)
+    row = [date, md_path.stem, str(pdf), str(mp3), str(social), sha, version]
+    csv_path = Path("metadata/content_index.csv")
+    exists = csv_path.exists()
+    with csv_path.open("a", newline="") as f:
+        writer = csv.writer(f)
+        if not exists:
+            writer.writerow(["date", "title", "pdf_path", "podcast_path", "social_path", "sha256", "version"])
+        writer.writerow(row)
+    print(f"✔ Metadata row appended to {csv_path}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 5:
+        sys.exit("Usage: update_metadata.py DIGEST_MD PDF MP3 SOCIAL_JSON")
+    update_csv(Path(sys.argv[1]), Path(sys.argv[2]), Path(sys.argv[3]), Path(sys.argv[4]))

--- a/templates/digest_template.md
+++ b/templates/digest_template.md
@@ -1,0 +1,26 @@
+# Section 1: Example
+- 📰 Example bullet.
+
+# Section 2: Example
+- 💡 Insight bullet.
+
+# Section 3: Example
+- 📈 Market bullet.
+
+# Section 4: Example
+- ⚙️ Tech bullet.
+
+# Section 5: Example
+- 🏛️ Policy bullet.
+
+# Section 6: Example
+- 🎓 Education bullet.
+
+# Section 7: Example
+- 📊 Data bullet.
+
+# Section 8: Example
+- 🚀 Next bullet.
+
+# Section 9: Example
+- 🎯 Conclusion bullet.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run automation on added digests
- implement new scripts to generate PDFs, social snippets, podcast scripts, audio and archives
- maintain a content index and template for digests
- document pipeline usage in README

## Testing
- `pytest -q`
- `ruff check .` *(fails: unrecognized subcommand)*

------
https://chatgpt.com/codex/tasks/task_e_6844ae213ed0832996570635885047bd